### PR TITLE
Fix Orca profile resolution: Node 24 crash and missing @base sibling

### DIFF
--- a/tools/inheritedprofile.js
+++ b/tools/inheritedprofile.js
@@ -11,7 +11,7 @@ const getGenericProfile = (profile, genericDir) => {
             if(name.endsWith('@System')) {
                 baseName = name.slice(0,-7)
                 baseName += '@base'
-                genericProfile = fs.readFileSync(entries[entry].path+ '/' + baseName + '.json')
+                genericProfile = fs.readFileSync(entries[entry].parentPath+ '/' + baseName + '.json')
                 genericProfileJson = JSON.parse(genericProfile)
                 if(genericProfileJson.inherits){
                     profiles.push(genericProfileJson)

--- a/tools/inheritedprofile.js
+++ b/tools/inheritedprofile.js
@@ -8,7 +8,7 @@ const getGenericProfile = (profile, genericDir) => {
     for (entry in entries) {
         let name = entries[entry].name.slice(0, -5)
         if (name == genericName) {
-            if(name.endsWith('@System')) {
+            if(name.endsWith('@System') && fs.existsSync(entries[entry].parentPath + '/' + name.slice(0,-7) + '@base.json')) {
                 baseName = name.slice(0,-7)
                 baseName += '@base'
                 genericProfile = fs.readFileSync(entries[entry].parentPath+ '/' + baseName + '.json')


### PR DESCRIPTION
Two small fixes to `getGenericProfile`, both in the `@System` branch.

**1. Node 24 crash (#23).** Line 14 still read `Dirent.path`, which returns `undefined` on Node 24, so `readFileSync` got an `undefined/...` path and threw ENOENT. `1ebdeef` switched the line 22 twin to `parentPath` but missed this one.

**2. Missing `@base` sibling.** The current OrcaFilamentLibrary ships `<name> @System` profiles without the `<name> @base` sibling this branch assumed, so it crashed with ENOENT on `<name> @base.json`. When that file is absent, the profile now falls through to the generic branch, which resolves the parent via its own `inherits` field (e.g. `Generic ASA @System` -> `fdm_filament_asa` -> `fdm_filament_common`). Installs that still have `@base` siblings are unaffected.

Tested against a current OrcaSlicer install on Node 22 and 24; a custom ASA profile now resolves to the full merged profile.