### PR TITLE
Reset inherited-profile state between profiles

### DIFF
--- a/tools/inheritedprofile.js
+++ b/tools/inheritedprofile.js
@@ -34,6 +34,7 @@ const getGenericProfile = (profile, genericDir) => {
 }
 
 const createCustomProfile = (profile, genericDir) => {
+    profiles = []
     profiles.push(profile)
     const genericProfiles = getGenericProfile(profile, genericDir)
     let newProfile = {}


### PR DESCRIPTION
`profiles` in `inheritedprofile.js` is a module-level array that `getGenericProfile` appends to and `createCustomProfile` merges. It is never cleared between calls, so each custom profile accumulates the previous ones, and the merge (which applies index 0 last) overwrites every profile with the first one processed.

Effect: with more than one custom filament, all but the first collapse into duplicates of the first — so only one brand/name actually reaches the printer.

Fix: reset the array at the start of each `createCustomProfile` call.

Verified against a real OrcaSlicer install: 13 custom profiles across 5 brands now resolve distinctly instead of collapsing to one.