### PR TITLE
Fix removeDuplicates emptying the material database

### DIFF
--- a/tools/database-tool.js
+++ b/tools/database-tool.js
@@ -25,18 +25,11 @@ const writeDatabase = (database) => {
 }
 
 const removeDuplicates = () => {
-    let databaseList = newDatabase.result.list
-    let filteredDatabase = databaseList
-    for(let entry = 0; entry <= startCount-1; entry++) {
-        let entryID = databaseList[entry].base.id
-        for(id of newIds) {
-            if(entryID == id) {
-                filteredDatabase = filteredDatabase.slice(entry+1, newDatabase.count)
-                newDatabase.result.count -=1
-            }
-        }
-    }
-    newDatabase.result.list = filteredDatabase
+    // Keep every profile we just added, plus any stock entry a custom profile didn't override
+    newDatabase.result.list = newDatabase.result.list.filter((entry, index) => {
+        return index >= startCount || !newIds.includes(entry.base.id)
+    })
+    newDatabase.result.count = newDatabase.result.list.length
     writeDatabase(newDatabase)
 }
 


### PR DESCRIPTION
`removeDuplicates` is meant to drop a stock entry when a custom profile reuses its id, so the custom one replaces it. Instead it deletes unrelated entries, and with enough collisions it empties the database completely — which then gets written and uploaded to the printer.

The line is:

```js
filteredDatabase = filteredDatabase.slice(entry+1, newDatabase.count)
```

`slice` returns the range *after* the index rather than removing that one element, so each collision discards everything before it. `entry` keeps walking the original list while `filteredDatabase` shrinks, so every further collision cuts deeper into an already truncated array. The end argument is `newDatabase.count`, which is `undefined` — the count lives at `newDatabase.result.count`.

Run against the seed database in `tools/sourcedata`, a profile using id `00001` (Generic PLA):

```
collision 00001 at index 9:  slice(10) -> list 84 => 74
```

One collision, 10 entries gone. Seven collisions (`00001`–`00007`, all Generic) leave the list empty while `result.count` still claims 75.

It's easy to hit because the notes template asks for a "unique 5-digit value" without saying unique against what, and `00001` is a natural first choice.

Replaced with a filter that keeps everything just added plus any stock entry no custom profile claimed, and takes the count from the resulting length so it can't drift from the list.

Tested on Node 22 and 24 against a real OrcaSlicer install: 13 custom profiles, database goes from 75 to 88 with `count` matching, and overriding a stock id now replaces exactly that one entry.
