### PR TITLE
Warn when a profile id clashes with a stock filament

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -173,13 +173,34 @@ Copy and paste this template into your profile notes:
 ```
 
 #### Important Rules for IDs:
-* The `"id"` must be a **unique 5-digit value**. 
+* The `"id"` must be a **unique 5-digit value**.
+* Unique means unique across **all** of your profiles, and not one of the IDs the printer's own filaments already use (see below).
 * If you are using custom RFID tags, this ID must match the tag.
 * ⚠️ **An ID is required** even if you don't use RFID tags, as the tool uses it to update printer settings.
 
 **Example configuration:**
 ```json
 {"id":"02345","vendor":"ELEGOO","type":"PLA","name":"Fast PLA"}
+```
+
+#### IDs already used by the built in filaments
+
+**Anything from `90000` up is free, so it's the easiest range to pick from.**
+
+If you give a profile one of the IDs below, your filament takes that slot and the built in filament stops showing on the printer. The tool warns you when it spots this, and asks before syncing if you're running it from a terminal. Nothing is lost permanently, change the ID back to a free one and sync again and the built in filament returns.
+
+If you already wrote the ID to an RFID tag, note that the tag still points at the old ID, so you'd need to rewrite the tag as well.
+
+```
+00001, 00002, 00003, 00004, 00005, 00006, 00007, 00008, 00009,
+00010, 00011, 00012, 00013, 00014, 00015, 00016, 00017, 00018,
+00019, 00020, 00021, 00022, 00023, 00024, 00025, 00026, 00027,
+00031, 00032, 00033, 00034, 00035, 01001, 01002, 01004, 01601,
+02001, 03001, 04001, 05001, 06001, 06002, 06003, 06004, 07001,
+07002, 08001, 09001, 09002, 10001, 11001, 12002, 12003, 12004,
+12005, 13001, 14001, 15001, 16001, 17001, 18001, 19001, 29001,
+E1001, E1002, E1003, E1004, E1005, E1006, E2001, E2002, P1001,
+P1002, P1003, P1004
 ```
 
 ### 2. If you are using custom RFID tags

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 const addOptions = require('./tools/options-tool.js')
 const addProfiles = require ('./tools/database-tool.js')
 const {initData} = require('./tools/config.js')
+const {checkIds} = require('./tools/id-check.js')
 const sendToPrinter = require('./tools/scp.js')
 const installService = require('./tools/service-installer.js')
 const autoUpdate = require('./tools/update.js')
@@ -10,6 +11,7 @@ const main = async () => {
         await autoUpdate()
         await installService()
         initData()
+        if (!await checkIds()) return
         addOptions()
         addProfiles()
         sendToPrinter()

--- a/tools/id-check.js
+++ b/tools/id-check.js
@@ -1,0 +1,86 @@
+// Warns when profile ids clash with a stock filament or with each other
+const fs = require('fs')
+const path = require('path')
+const readline = require('readline/promises')
+const databaseFile = path.join(__dirname, '..', 'data', 'material_database.json')
+const {readProfiles} = require('./config')
+
+const readNotes = (profile) => {
+    let notes = profile.filament_notes
+    if (Array.isArray(notes)) notes = notes[0]
+    return typeof notes == 'string' ? JSON.parse(notes) : notes
+}
+
+const readName = (profile, notes) => {
+    let name = notes.name || profile.name
+    return Array.isArray(name) ? name[0] : name
+}
+
+const findIdProblems = (profiles, stockList) => {
+    let collisions = []
+    let usedIds = {}
+    for (let profile of profiles) {
+        let notes = readNotes(profile)
+        let name = readName(profile, notes)
+        let stock = stockList.find(entry => entry.base.id == notes.id)
+        if (stock) {
+            collisions.push({
+                id: notes.id,
+                profileName: name,
+                stockBrand: stock.base.brand,
+                stockName: stock.base.name
+            })
+        }
+        if (usedIds[notes.id] == undefined) usedIds[notes.id] = []
+        usedIds[notes.id].push(name)
+    }
+    let duplicates = Object.keys(usedIds)
+        .filter(id => usedIds[id].length > 1)
+        .map(id => ({id: id, profileNames: usedIds[id]}))
+    return {collisions: collisions, duplicates: duplicates}
+}
+
+const printProblems = (problems) => {
+    if (problems.collisions.length) {
+        console.warn('\nThese profiles use an id that a stock filament already owns:')
+        for (let hit of problems.collisions) {
+            let stock = hit.stockName.startsWith(hit.stockBrand) ? hit.stockName : `${hit.stockBrand} ${hit.stockName}`
+            console.warn(`  ${hit.id}  "${hit.profileName}" replaces ${stock}`)
+        }
+        console.warn('The stock filament will not show on the printer while that id is in use.')
+        console.warn('To get it back, give your profile an unused id (90000 and up is free) and sync again.')
+        console.warn('If you already wrote this id to an RFID tag, the tag keeps pointing at the old id.')
+    }
+    if (problems.duplicates.length) {
+        console.warn('\nThese profiles share an id with each other:')
+        for (let duplicate of problems.duplicates) {
+            console.warn(`  ${duplicate.id}  ${duplicate.profileNames.join(', ')}`)
+        }
+        console.warn('Every profile needs its own 5 digit id or the printer cannot tell them apart.')
+    }
+}
+
+const askUser = async (question) => {
+    const prompt = readline.createInterface({input: process.stdin, output: process.stdout})
+    const answer = await prompt.question(question)
+    prompt.close()
+    return answer
+}
+
+const checkIds = async (ask = askUser) => {
+    let database = JSON.parse(fs.readFileSync(databaseFile))
+    let problems = findIdProblems(readProfiles(), database.result.list)
+    if (!problems.collisions.length && !problems.duplicates.length) return true
+    printProblems(problems)
+    // Runs headless as a slicer post processing script, so only prompt with a terminal attached
+    if (!process.stdin.isTTY) {
+        console.warn('\nNo terminal attached, syncing anyway.')
+        return true
+    }
+    let answer = await ask('\nSync anyway? [y/N] ')
+    if (answer.trim().toLowerCase().startsWith('y')) return true
+    console.warn('Sync cancelled, nothing was sent to the printer.')
+    return false
+}
+
+module.exports = {checkIds, findIdProblems}


### PR DESCRIPTION
The notes template asks for a unique 5-digit id but doesn't say unique against what, so it's easy to pick one the built in filaments already use. When that happens your filament takes that slot and the built in one stops showing on the printer, which reads like a sync failure. Nothing warned about it. Two profiles sharing an id went unnoticed too.

Adds `tools/id-check.js`, called from `main.js` after `initData()`:

```
These profiles use an id that a stock filament already owns:
  00001  "PLA Matte" replaces Generic PLA
The stock filament will not show on the printer while that id is in use.
To get it back, give your profile an unused id (90000 and up is free) and sync again.
If you already wrote this id to an RFID tag, the tag keeps pointing at the old id.

Sync anyway? [y/N]
```

It only prompts when there's a terminal attached. Run headless as a slicer post processing script there's no TTY, so it prints the warning and carries on rather than hanging the slice. Declining stops before anything is written or uploaded.

It runs before `addProfiles` because `convertToPrinterFormat` rewrites the presets in place, so afterwards the original shape is gone.

README now lists the ids the built in filaments use, suggests 90000 and up, and notes the RFID tag caveat.

Sits on top of #27 — without that fix, choosing to override still empties the database, so the warning would be describing behaviour that doesn't work yet.

Tested against a real OrcaSlicer install: clean ids pass silently, a simulated collision warns and prompts correctly, and declining aborts the sync.
